### PR TITLE
Enable common driver and odbc path configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/HGInsights/gimme-snowflake-creds/pkg/utils"
 	"github.com/go-playground/validator"
 	"github.com/hashicorp/go-hclog"
 )
@@ -24,27 +25,32 @@ var (
 )
 
 type Configuration struct {
-	Profile      string
-	Default      string `mapstructure:"default"`
-	Account      string `mapstructure:"account" validate:"required"`
-	Database     string `mapstructure:"database" validate:"required"`
-	Warehouse    string `mapstructure:"warehouse" validate:"required"`
-	Schema       string `mapstructure:"schema"`
-	OAuth        bool   `mapstructure:"oauth"`
-	Generic      bool   `mapstructure:"generic"`
-	OktaOrg      string `mapstructure:"okta-org" validate:"required,url"`
-	ODBCPath     string `mapstructure:"odbc-path" validate:"required"`
-	ODBCDriver   string `mapstructure:"odbc-driver" validate:"required"`
-	ClientID     string `mapstructure:"client-id" validate:"required"`
-	Role         string `mapstructure:"role" validate:"required"`
-	IssuerURL    string `mapstructure:"issuer-url" validate:"required,url"`
-	RedirectURI  string `mapstructure:"redirect-uri" validate:"required,uri"`
-	Username     string `mapstructure:"username" validate:"required,email"`
-	Password     string
-	HomeDir      string
-	Logger       hclog.Logger
-	ColorSuccess string
-	ColorFailure string
+	DefaultProfile string `mapstructure:"default"`
+	ODBCDriverName string `mapstructure:"driver-name" validate:"required"`
+	ODBCDriverPath string `mapstructure:"driver-path" validate:"required"`
+	ProfileName    string
+	Profile        Profile
+	HomeDir        string
+	Logger         hclog.Logger
+	ColorSuccess   string
+	ColorFailure   string
+}
+
+type Profile struct {
+	OAuth       bool   `mapstructure:"oauth"`
+	Generic     bool   `mapstructure:"generic"`
+	Account     string `mapstructure:"account" validate:"required"`
+	Database    string `mapstructure:"database" validate:"required"`
+	Warehouse   string `mapstructure:"warehouse" validate:"required"`
+	Schema      string `mapstructure:"schema"`
+	OktaOrg     string `mapstructure:"okta-org" validate:"required,url"`
+	ODBCPath    string `mapstructure:"odbc-path" validate:"required"`
+	ClientID    string `mapstructure:"client-id" validate:"required"`
+	Role        string `mapstructure:"role" validate:"required"`
+	IssuerURL   string `mapstructure:"issuer-url" validate:"required,url"`
+	RedirectURI string `mapstructure:"redirect-uri" validate:"required,uri"`
+	Username    string `mapstructure:"username" validate:"required,email"`
+	Password    string
 }
 
 type Credentials struct {
@@ -52,14 +58,19 @@ type Credentials struct {
 	AccessToken string
 }
 
-func LoadDefaults(p *Configuration) error {
-	p.ColorSuccess = colorGreen
-	p.ColorFailure = colorRed
+func LoadDefaults(c *Configuration) error {
+	c.ColorSuccess = colorGreen
+	c.ColorFailure = colorRed
+
+	if utils.InDocker() {
+		c.Logger.Debug("Running in Docker!")
+		c.Profile.ODBCPath = "/root/Library/ODBC"
+	}
 
 	return nil
 }
 
-func ValidateConfiguration(p *Configuration) error {
+func ValidateConfiguration(c *Configuration) error {
 	validate = validator.New()
 
 	// Register function to get tag name from mapstructure tags
@@ -71,13 +82,13 @@ func ValidateConfiguration(p *Configuration) error {
 		return name
 	})
 
-	err := validate.Struct(p)
+	err := validate.Struct(c)
 	if err != nil {
 		for _, err := range err.(validator.ValidationErrors) {
-			if !p.OAuth && contains(oauthParams, err.Field()) {
+			if !c.Profile.OAuth && contains(oauthParams, err.Field()) {
 				return nil
 			} else {
-				fmt.Println(string(p.ColorFailure), "Parameter", err.Field(), "is required")
+				fmt.Println(string(c.ColorFailure), "Parameter", err.Field(), "is required")
 			}
 		}
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -9,108 +9,112 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-func WriteGenericCredentials(p config.Configuration, t *config.Credentials) error {
-	var genericConfigPath = p.HomeDir + "/.gsc/" + p.Profile
+func WriteGenericCredentials(c config.Configuration, t *config.Credentials) error {
+	var genericConfigPath = c.HomeDir + "/.gsc/" + c.ProfileName
 	var genericConfigFile = genericConfigPath + "/credentials"
 
 	// Ensure `~/.gsc` directory exists
 	if _, err := os.Stat(genericConfigPath); os.IsNotExist(err) {
-		p.Logger.Debug("Couldn't find existing generic configuration path, creating...", "error", err)
+		c.Logger.Debug("Couldn't find existing generic configuration path, creating...", "error", err)
 		os.MkdirAll(genericConfigPath, os.ModePerm)
 	}
 
 	generic, err := ini.Load(genericConfigFile)
 	if err != nil {
-		fmt.Println(string(p.ColorSuccess), "Generic: No existing configuration found, creating file...")
-		p.Logger.Debug("Couldn't read existing generic config", "error", err)
+		fmt.Println(string(c.ColorSuccess), "Generic: No existing configuration found, creating file...")
+		c.Logger.Debug("Couldn't read existing generic config", "error", err)
 		generic = ini.Empty()
 	}
 
-	generic.Section("").Key("SNOWFLAKE_USER").SetValue(p.Username)
+	generic.Section("").Key("SNOWFLAKE_USER").SetValue(c.Profile.Username)
 	generic.Section("").Key("SNOWFLAKE_OAUTH_ACCESS_TOKEN").SetValue(t.AccessToken)
 
 	err = generic.SaveTo(genericConfigFile)
 	if err != nil {
-		fmt.Println(string(p.ColorFailure), "Generic: Couldn't write config!")
-		p.Logger.Debug("Couldn't write generic config", "error", err)
+		fmt.Println(string(c.ColorFailure), "Generic: Couldn't write config!")
+		c.Logger.Debug("Couldn't write generic config", "error", err)
 		return err
 	}
 
-	fmt.Println(string(p.ColorSuccess), "Generic: Configuration written to:", genericConfigFile)
+	fmt.Println(string(c.ColorSuccess), "Generic: Configuration written to:", genericConfigFile)
 
 	return nil
 }
 
-func WriteODBCConfig(p config.Configuration, t *config.Credentials) error {
-	var odbcConfigFile = p.ODBCPath + "/odbc.ini"
-	var serverURL = p.Account + ".snowflakecomputing.com"
+func WriteODBCConfig(c config.Configuration, t *config.Credentials) error {
+	var odbcConfigFile = c.Profile.ODBCPath + "/odbc.ini"
+	var serverURL = c.Profile.Account + ".snowflakecomputing.com"
 
 	// Ensure ODBC path defined by user exists
-	if _, err := os.Stat(p.ODBCPath); os.IsNotExist(err) {
-		p.Logger.Debug("Couldn't find existing ODBC path, creating...", "error", err)
-		os.Mkdir(p.ODBCPath, os.ModePerm)
+	if _, err := os.Stat(c.Profile.ODBCPath); os.IsNotExist(err) {
+		c.Logger.Debug("Couldn't find existing ODBC path, creating...", "error", err)
+		os.Mkdir(c.Profile.ODBCPath, os.ModePerm)
 	}
 
 	odbc, err := ini.Load(odbcConfigFile)
 	if err != nil {
-		fmt.Println(string(p.ColorSuccess), "ODBC: No existing configuration found, creating file...")
-		p.Logger.Debug("Couldn't read existing ODBC config", "error", err)
+		fmt.Println(string(c.ColorSuccess), "ODBC: No existing configuration found, creating file...")
+		c.Logger.Debug("Couldn't read existing ODBC config", "error", err)
 		odbc = ini.Empty()
 	}
 
-	odbc.Section(p.Profile).Key("Driver").SetValue(p.ODBCDriver)
-	odbc.Section(p.Profile).Key("server").SetValue(serverURL)
-	odbc.Section(p.Profile).Key("uid").SetValue(p.Username)
-	odbc.Section(p.Profile).Key("role").SetValue(p.Role)
-	odbc.Section(p.Profile).Key("database").SetValue(p.Database)
-	odbc.Section(p.Profile).Key("schema").SetValue(p.Schema)
-	odbc.Section(p.Profile).Key("warehouse").SetValue(p.Warehouse)
+	// Create driver alias
+	odbc.Section(c.ODBCDriverName).Key("Driver").SetValue(c.ODBCDriverPath)
 
-	if p.OAuth {
-		odbc.Section(p.Profile).Key("authenticator").SetValue("oauth")
-		odbc.Section(p.Profile).Key("token").SetValue(t.AccessToken)
+	// Create profile DSN
+	odbc.Section(c.ProfileName).Key("Driver").SetValue(c.ODBCDriverName)
+	odbc.Section(c.ProfileName).Key("server").SetValue(serverURL)
+	odbc.Section(c.ProfileName).Key("uid").SetValue(c.Profile.Username)
+	odbc.Section(c.ProfileName).Key("role").SetValue(c.Profile.Role)
+	odbc.Section(c.ProfileName).Key("database").SetValue(c.Profile.Database)
+	odbc.Section(c.ProfileName).Key("schema").SetValue(c.Profile.Schema)
+	odbc.Section(c.ProfileName).Key("warehouse").SetValue(c.Profile.Warehouse)
+
+	if c.Profile.OAuth {
+		odbc.Section(c.ProfileName).Key("authenticator").SetValue("oauth")
+		odbc.Section(c.ProfileName).Key("token").SetValue(t.AccessToken)
 	} else {
-		odbc.Section(p.Profile).Key("authenticator").SetValue("externalbrowser")
+		odbc.Section(c.ProfileName).Key("authenticator").SetValue("externalbrowser")
 	}
 
 	err = odbc.SaveTo(odbcConfigFile)
 	if err != nil {
-		fmt.Println(string(p.ColorFailure), "ODBC: Couldn't write config!")
-		p.Logger.Debug("Couldn't write ODBC config", "error", err)
+		fmt.Println(string(c.ColorFailure), "ODBC: Couldn't write config!")
+		c.Logger.Debug("Couldn't write ODBC config", "error", err)
 		return err
 	}
 
-	fmt.Println(string(p.ColorSuccess), "ODBC: Configuration written to:", odbcConfigFile)
+	fmt.Println(string(c.ColorSuccess), "ODBC: Configuration written to:", odbcConfigFile)
 
 	return nil
 }
 
-func WriteDBTConfig(p config.Configuration, t *config.Credentials) error {
-	var dbtConfigPath = p.HomeDir + "/.dbt"
+func WriteDBTConfig(c config.Configuration, t *config.Credentials) error {
+	var dbtConfigPath = c.HomeDir + "/.dbt"
 	var dbtConfigFile = dbtConfigPath + "/profiles.yml"
 
 	var dbt = viper.New()
 	dbt.SetConfigFile(dbtConfigFile)
-	dbt.Set("default.target", p.Default)
+	dbt.Set("default.target", c.DefaultProfile)
 
 	// Ensure DBT configuration directory exists
 	if _, err := os.Stat(dbtConfigPath); os.IsNotExist(err) {
-		p.Logger.Debug("Couldn't find existing DBT configuration directory, creating...", "error", err)
+		c.Logger.Debug("Couldn't find existing DBT configuration directory, creating...", "error", err)
 		os.Mkdir(dbtConfigPath, os.ModePerm)
 	}
 
-	if p.OAuth {
+	if c.Profile.OAuth {
 		profile := map[string]interface{}{
-			string(p.Profile): map[string]interface{}{
+			string(c.ProfileName): map[string]interface{}{
 				"type":                      "snowflake",
-				"account":                   p.Account,
-				"user":                      p.Username,
+				"account":                   c.Profile.Account,
+				"user":                      c.Profile.Username,
 				"authenticator":             "oauth",
 				"token":                     t.AccessToken,
-				"role":                      p.Role,
-				"database":                  p.Database,
-				"warehouse":                 p.Warehouse,
-				"schema":                    p.Schema,
+				"role":                      c.Profile.Role,
+				"database":                  c.Profile.Database,
+				"warehouse":                 c.Profile.Warehouse,
+				"schema":                    c.Profile.Schema,
 				"threads":                   10,
 				"client_session_keep_alive": false,
 			},
@@ -119,15 +123,15 @@ func WriteDBTConfig(p config.Configuration, t *config.Credentials) error {
 		dbt.Set("default.outputs", profile)
 	} else {
 		profile := map[string]interface{}{
-			string(p.Profile): map[string]interface{}{
+			string(c.ProfileName): map[string]interface{}{
 				"type":                      "snowflake",
-				"account":                   p.Account,
-				"user":                      p.Username,
+				"account":                   c.Profile.Account,
+				"user":                      c.Profile.Username,
 				"authenticator":             "externalbrowser",
-				"role":                      p.Role,
-				"database":                  p.Database,
-				"warehouse":                 p.Warehouse,
-				"schema":                    p.Schema,
+				"role":                      c.Profile.Role,
+				"database":                  c.Profile.Database,
+				"warehouse":                 c.Profile.Warehouse,
+				"schema":                    c.Profile.Schema,
 				"threads":                   10,
 				"client_session_keep_alive": false,
 			},
@@ -138,17 +142,17 @@ func WriteDBTConfig(p config.Configuration, t *config.Credentials) error {
 
 	err := dbt.ReadInConfig()
 	if err != nil {
-		fmt.Println(string(p.ColorSuccess), "DBT: No existing configuration found, creating file...")
-		p.Logger.Debug("Couldn't read existing DBT config", "error", err)
+		fmt.Println(string(c.ColorSuccess), "DBT: No existing configuration found, creating file...")
+		c.Logger.Debug("Couldn't read existing DBT config", "error", err)
 	}
 	err = dbt.WriteConfig()
 	if err != nil {
-		fmt.Println(string(p.ColorFailure), "DBT: Couldn't write config!")
-		p.Logger.Debug("Couldn't write DBT config", "error", err)
+		fmt.Println(string(c.ColorFailure), "DBT: Couldn't write config!")
+		c.Logger.Debug("Couldn't write DBT config", "error", err)
 		return err
 	}
 
-	fmt.Println(string(p.ColorSuccess), "DBT: Configuration written to:", dbtConfigFile)
+	fmt.Println(string(c.ColorSuccess), "DBT: Configuration written to:", dbtConfigFile)
 
 	return nil
 }

--- a/pkg/okta/okta.go
+++ b/pkg/okta/okta.go
@@ -56,114 +56,114 @@ type tokenResponse struct {
 	AccessToken string `json:"access_token"`
 }
 
-func Auth(p config.Configuration) (*config.Credentials, error) {
-	c := new(config.Credentials)
+func Auth(c config.Configuration) (*config.Credentials, error) {
+	p := new(config.Credentials)
 
-	if p.OAuth {
+	if c.Profile.OAuth {
 		// Prompt for Okta password
-		p, err := passwordPrompt(p)
+		c, err := passwordPrompt(c)
 		if err != nil {
-			p.Logger.Debug("Unable to return password prompt input", "error", err)
+			c.Logger.Debug("Unable to return password prompt input", "error", err)
 			os.Exit(0)
 		}
 
 		// Perform primary, initial authentication
-		authn, err := primaryAuth(p)
+		authn, err := primaryAuth(c)
 		if err != nil {
-			p.Logger.Debug("Unable to return primary authentication response", "error", err)
+			c.Logger.Debug("Unable to return primary authentication response", "error", err)
 			os.Exit(0)
 		}
 
 		if authn.Status == "SUCCESS" {
 			// Retrieve OAuth token
-			token, err := oauthToken(p, nil)
+			token, err := oauthToken(c, nil)
 			if err != nil {
-				p.Logger.Debug("Unable to return OAuth token", "error", err)
+				c.Logger.Debug("Unable to return OAuth token", "error", err)
 				os.Exit(0)
 			}
 
-			c.ExpiresIn = token.ExpiresIn
-			c.AccessToken = token.AccessToken
+			p.ExpiresIn = token.ExpiresIn
+			p.AccessToken = token.AccessToken
 
-			return c, nil
+			return p, nil
 		} else if authn.Status == "MFA_REQUIRED" {
 			// Prompt for factor type
-			factor, err := factorSelect(p, authn)
+			factor, err := factorSelect(c, authn)
 			if err != nil {
-				p.Logger.Debug("Unable to return factor selection", "error", err)
+				c.Logger.Debug("Unable to return factor selection", "error", err)
 				os.Exit(0)
 			}
 
-			err = factorPush(p, authn, factor)
+			err = factorPush(c, authn, factor)
 			if err != nil {
-				p.Logger.Debug("Unable to initiate factor push", "error", err)
+				c.Logger.Debug("Unable to initiate factor push", "error", err)
 				os.Exit(0)
 			}
 
 			// Prompt for factor challenge
-			challenge, err := factorChallenge(p, factor)
+			challenge, err := factorChallenge(c, factor)
 			if err != nil {
-				p.Logger.Debug("Unable to return factor challenge", "error", err)
+				c.Logger.Debug("Unable to return factor challenge", "error", err)
 				os.Exit(0)
 			}
 
 			// Perform MFA verification
-			verify, err := verifyMFA(p, authn, factor, challenge)
+			verify, err := verifyMFA(c, authn, factor, challenge)
 			for verify.FactorResult == "WAITING" {
-				p.Logger.Debug("Checking MFA verification...")
+				c.Logger.Debug("Checking MFA verification...")
 				time.Sleep(1 * time.Second)
-				verify, err = verifyMFA(p, authn, factor, challenge)
+				verify, err = verifyMFA(c, authn, factor, challenge)
 			}
 			if verify.FactorResult == "REJECTED" {
-				fmt.Println(string(p.ColorFailure), "MFA challenge rejected!")
+				fmt.Println(string(c.ColorFailure), "MFA challenge rejected!")
 				os.Exit(0)
 			} else if verify.FactorResult == "TIMEOUT" {
-				fmt.Println(string(p.ColorSuccess), "MFA challenge timed out!")
+				fmt.Println(string(c.ColorSuccess), "MFA challenge timed out!")
 				os.Exit(0)
 			} else if verify.Status == "SUCCESS" {
-				fmt.Println(string(p.ColorSuccess), "MFA verified!")
+				fmt.Println(string(c.ColorSuccess), "MFA verified!")
 			}
 			if err != nil {
-				fmt.Println(string(p.ColorFailure), "MFA verification failed!")
-				p.Logger.Debug("Unable to return MFA verifcation", "error", err)
+				fmt.Println(string(c.ColorFailure), "MFA verification failed!")
+				c.Logger.Debug("Unable to return MFA verifcation", "error", err)
 				os.Exit(0)
 			}
 
 			// Retrieve authorizataion code
-			auth, err := authCode(p, verify)
+			auth, err := authCode(c, verify)
 			if err != nil {
-				p.Logger.Debug("Unable to return authorization code", "error", err)
+				c.Logger.Debug("Unable to return authorization code", "error", err)
 				os.Exit(0)
 			}
 
 			// Retrieve OAuth token
-			token, err := oauthToken(p, auth)
+			token, err := oauthToken(c, auth)
 			if err != nil {
-				p.Logger.Debug("Unable to return OAuth token", "error", err)
+				c.Logger.Debug("Unable to return OAuth token", "error", err)
 				os.Exit(0)
 			}
 
-			c.ExpiresIn = token.ExpiresIn
-			c.AccessToken = token.AccessToken
+			p.ExpiresIn = token.ExpiresIn
+			p.AccessToken = token.AccessToken
 
-			return c, nil
+			return p, nil
 		} else {
-			p.Logger.Debug("Something went very wrong...")
+			c.Logger.Debug("Something went very wrong...")
 			os.Exit(0)
 		}
 	}
 
-	return c, nil
+	return p, nil
 }
 
-func primaryAuth(p config.Configuration) (*authnResponse, error) {
-	uri := p.OktaOrg + "/api/v1/authn"
+func primaryAuth(c config.Configuration) (*authnResponse, error) {
+	uri := c.Profile.OktaOrg + "/api/v1/authn"
 
 	r := new(authnResponse)
 
 	payload := map[string]interface{}{
-		"username": p.Username,
-		"password": p.Password,
+		"username": c.Profile.Username,
+		"password": c.Profile.Password,
 		"options": map[string]interface{}{
 			"multiOptionalFactorEnroll": true,
 			"warnBeforePasswordExpired": false,
@@ -176,40 +176,40 @@ func primaryAuth(p config.Configuration) (*authnResponse, error) {
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Content-Type", "application/json")
 
-	c := &http.Client{
+	h := &http.Client{
 		Timeout: 10 * time.Second,
 	}
 
-	resp, err := c.Do(req)
+	resp, err := h.Do(req)
 	if err != nil {
-		fmt.Println(string(p.ColorFailure), "Unknown error: is the network up?")
-		p.Logger.Debug("HTTP request failed", "error", err)
+		fmt.Println(string(c.ColorFailure), "Unknown error: is the network up?")
+		c.Logger.Debug("HTTP request failed", "error", err)
 		os.Exit(0)
 	}
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
-		fmt.Println(string(p.ColorFailure), "Invalid password!")
+		fmt.Println(string(c.ColorFailure), "Invalid password!")
 		os.Exit(0)
 	} else if resp.StatusCode != http.StatusOK {
-		p.Logger.Debug("Primary: HTTP is not OK", "status", resp.StatusCode, "error", err)
+		c.Logger.Debug("Primary: HTTP is not OK", "status", resp.StatusCode, "error", err)
 		os.Exit(0)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		p.Logger.Debug("Unable to read response body", "error", err)
+		c.Logger.Debug("Unable to read response body", "error", err)
 		os.Exit(0)
 	}
 
 	err = json.Unmarshal(body, &r)
 	if err != nil {
-		p.Logger.Debug("Unable to unmarshal response body", "error", err)
+		c.Logger.Debug("Unable to unmarshal response body", "error", err)
 		os.Exit(0)
 	}
 
 	return r, nil
 }
 
-func verifyMFA(p config.Configuration, authn *authnResponse, factor *factor, challenge string) (*verifyResponse, error) {
+func verifyMFA(c config.Configuration, authn *authnResponse, factor *factor, challenge string) (*verifyResponse, error) {
 	uri := factor.Links.Verify.VerifyURL
 
 	r := new(verifyResponse)
@@ -225,40 +225,40 @@ func verifyMFA(p config.Configuration, authn *authnResponse, factor *factor, cha
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Content-Type", "application/json")
 
-	c := &http.Client{
+	h := &http.Client{
 		Timeout: 10 * time.Second,
 	}
 
-	resp, err := c.Do(req)
+	resp, err := h.Do(req)
 	if err != nil {
-		p.Logger.Debug("HTTP request failed", "error", err)
+		c.Logger.Debug("HTTP request failed", "error", err)
 		os.Exit(0)
 	}
 	if resp.StatusCode == http.StatusForbidden {
-		fmt.Println(string(p.ColorFailure), "Invalid challenge!")
+		fmt.Println(string(c.ColorFailure), "Invalid challenge!")
 		os.Exit(0)
 	} else if resp.StatusCode != http.StatusOK {
-		p.Logger.Debug("Verify: HTTP is not OK", "status", resp.StatusCode, "error", err)
+		c.Logger.Debug("Verify: HTTP is not OK", "status", resp.StatusCode, "error", err)
 		os.Exit(0)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		p.Logger.Debug("Unable to read response body", "error", err)
+		c.Logger.Debug("Unable to read response body", "error", err)
 		os.Exit(0)
 	}
 
 	err = json.Unmarshal(body, &r)
 	if err != nil {
-		p.Logger.Debug("Unable to unmarshal response body", "error", err)
+		c.Logger.Debug("Unable to unmarshal response body", "error", err)
 		os.Exit(0)
 	}
 
 	return r, nil
 }
 
-func authCode(p config.Configuration, verify *verifyResponse) (*authorizeResponse, error) {
-	uri := p.IssuerURL + "/v1/authorize"
+func authCode(c config.Configuration, verify *verifyResponse) (*authorizeResponse, error) {
+	uri := c.Profile.IssuerURL + "/v1/authorize"
 
 	r := new(authorizeResponse)
 	scope := "session:role-any"
@@ -272,10 +272,10 @@ func authCode(p config.Configuration, verify *verifyResponse) (*authorizeRespons
 	codeChallenge := v.CodeChallengeS256()
 
 	payload := url.Values{}
-	payload.Set("client_id", p.ClientID)
+	payload.Set("client_id", c.Profile.ClientID)
 	payload.Set("response_type", "code")
 	payload.Set("scope", scope)
-	payload.Set("redirect_uri", p.RedirectURI)
+	payload.Set("redirect_uri", c.Profile.RedirectURI)
 	payload.Set("state", uuid.NewString())
 	payload.Set("sessionToken", verify.SessionToken)
 	payload.Set("code_challenge", codeChallenge)
@@ -284,26 +284,26 @@ func authCode(p config.Configuration, verify *verifyResponse) (*authorizeRespons
 	req, _ := http.NewRequest("GET", uri, nil)
 	req.URL.RawQuery = payload.Encode()
 
-	c := &http.Client{
+	h := &http.Client{
 		Timeout: 10 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}
 
-	resp, err := c.Do(req)
+	resp, err := h.Do(req)
 	if err != nil {
-		p.Logger.Debug("HTTP request failed", "error", err)
+		c.Logger.Debug("HTTP request failed", "error", err)
 		os.Exit(0)
 	}
 	if resp.StatusCode != http.StatusFound {
-		p.Logger.Debug("Authorize: HTTP is not 302!", "status", resp.StatusCode, "error", err)
+		c.Logger.Debug("Authorize: HTTP is not 302!", "status", resp.StatusCode, "error", err)
 		os.Exit(0)
 	}
 
 	location, err := resp.Location()
 	if err != nil {
-		p.Logger.Debug("Unable to read response location", "error", err)
+		c.Logger.Debug("Unable to read response location", "error", err)
 		os.Exit(0)
 	}
 
@@ -313,8 +313,8 @@ func authCode(p config.Configuration, verify *verifyResponse) (*authorizeRespons
 	return r, nil
 }
 
-func oauthToken(p config.Configuration, auth *authorizeResponse) (*tokenResponse, error) {
-	uri := p.IssuerURL + "/v1/token"
+func oauthToken(c config.Configuration, auth *authorizeResponse) (*tokenResponse, error) {
+	uri := c.Profile.IssuerURL + "/v1/token"
 
 	r := new(tokenResponse)
 	scope := "session:role-any"
@@ -322,17 +322,17 @@ func oauthToken(p config.Configuration, auth *authorizeResponse) (*tokenResponse
 	payload := url.Values{}
 
 	if auth != nil {
-		payload.Set("client_id", p.ClientID)
+		payload.Set("client_id", c.Profile.ClientID)
 		payload.Set("grant_type", "authorization_code")
 		payload.Set("code", auth.Code)
 		payload.Set("code_verifier", auth.CodeVerifier)
-		payload.Set("redirect_uri", p.RedirectURI)
+		payload.Set("redirect_uri", c.Profile.RedirectURI)
 		payload.Set("scope", scope)
 	} else {
-		payload.Set("client_id", p.ClientID)
+		payload.Set("client_id", c.Profile.ClientID)
 		payload.Set("grant_type", "password")
-		payload.Set("username", p.Username)
-		payload.Set("password", p.Password)
+		payload.Set("username", c.Profile.Username)
+		payload.Set("password", c.Profile.Password)
 		payload.Set("scope", scope)
 	}
 
@@ -341,40 +341,40 @@ func oauthToken(p config.Configuration, auth *authorizeResponse) (*tokenResponse
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
 
-	c := &http.Client{
+	h := &http.Client{
 		Timeout: 10 * time.Second,
 	}
 
-	resp, err := c.Do(req)
+	resp, err := h.Do(req)
 	if err != nil {
-		p.Logger.Debug("HTTP request failed", "error", err, "response", resp)
+		c.Logger.Debug("HTTP request failed", "error", err, "response", resp)
 		os.Exit(0)
 	}
 	if resp.StatusCode == http.StatusBadRequest {
-		fmt.Println(string(p.ColorFailure), "Bad request: maybe check Okta privileges?")
-		p.Logger.Debug("OAuth: HTTP 400", "error", err, "response", resp)
+		fmt.Println(string(c.ColorFailure), "Bad request: maybe check Okta privileges?")
+		c.Logger.Debug("OAuth: HTTP 400", "error", err, "response", resp)
 		os.Exit(0)
 	} else if resp.StatusCode != http.StatusOK {
-		p.Logger.Debug("OAuth: HTTP is not OK", "status", resp.StatusCode, "error", err)
+		c.Logger.Debug("OAuth: HTTP is not OK", "status", resp.StatusCode, "error", err)
 		os.Exit(0)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		p.Logger.Debug("Unable to read response body", "error", err)
+		c.Logger.Debug("Unable to read response body", "error", err)
 		os.Exit(0)
 	}
 
 	err = json.Unmarshal(body, &r)
 	if err != nil {
-		p.Logger.Debug("Unable to unmarshal response body", "error", err)
+		c.Logger.Debug("Unable to unmarshal response body", "error", err)
 		os.Exit(0)
 	}
 
 	return r, nil
 }
 
-func factorPush(p config.Configuration, authn *authnResponse, factor *factor) error {
+func factorPush(c config.Configuration, authn *authnResponse, factor *factor) error {
 	uri := factor.Links.Verify.VerifyURL
 
 	payload := map[string]interface{}{
@@ -386,32 +386,32 @@ func factorPush(p config.Configuration, authn *authnResponse, factor *factor) er
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 
-	c := &http.Client{
+	h := &http.Client{
 		Timeout: 10 * time.Second,
 	}
 
-	resp, err := c.Do(req)
+	resp, err := h.Do(req)
 	if err != nil {
-		p.Logger.Debug("HTTP request failed", "error", err)
+		c.Logger.Debug("HTTP request failed", "error", err)
 		os.Exit(0)
 	}
 	if resp.StatusCode == http.StatusTooManyRequests {
-		fmt.Println(string(p.ColorFailure), "Slow down! Wait a few moments...")
+		fmt.Println(string(c.ColorFailure), "Slow down! Wait a few moments...")
 		os.Exit(0)
 	} else if resp.StatusCode != http.StatusOK {
-		p.Logger.Debug("Push: HTTP is not OK", "status", resp.StatusCode, "error", err)
+		c.Logger.Debug("Push: HTTP is not OK", "status", resp.StatusCode, "error", err)
 		os.Exit(0)
 	}
 
 	if typeFactor("challenge", factor.FactorType) {
-		fmt.Println(string(p.ColorSuccess), "MFA challenge sent!")
+		fmt.Println(string(c.ColorSuccess), "MFA challenge sent!")
 	}
 
 	return nil
 }
 
-func passwordPrompt(p config.Configuration) (config.Configuration, error) {
-	label := "Okta password for " + p.Username
+func passwordPrompt(c config.Configuration) (config.Configuration, error) {
+	label := "Okta password for " + c.Profile.Username
 
 	validate := func(input string) error {
 		if len(input) == 0 {
@@ -428,16 +428,16 @@ func passwordPrompt(p config.Configuration) (config.Configuration, error) {
 
 	result, err := prompt.Run()
 	if err != nil {
-		p.Logger.Debug("Prompt failed", "error", err)
+		c.Logger.Debug("Prompt failed", "error", err)
 		os.Exit(0)
 	}
 
-	p.Password = result
+	c.Profile.Password = result
 
-	return p, nil
+	return c, nil
 }
 
-func factorSelect(p config.Configuration, resp *authnResponse) (*factor, error) {
+func factorSelect(c config.Configuration, resp *authnResponse) (*factor, error) {
 	factors := []string{}
 
 	var r = new(factor)
@@ -453,7 +453,7 @@ func factorSelect(p config.Configuration, resp *authnResponse) (*factor, error) 
 
 	_, result, err := prompt.Run()
 	if err != nil {
-		p.Logger.Debug("Prompt failed", "error", err)
+		c.Logger.Debug("Prompt failed", "error", err)
 		os.Exit(0)
 	}
 
@@ -467,7 +467,7 @@ func factorSelect(p config.Configuration, resp *authnResponse) (*factor, error) 
 	return nil, nil
 }
 
-func factorChallenge(p config.Configuration, factor *factor) (string, error) {
+func factorChallenge(c config.Configuration, factor *factor) (string, error) {
 	if typeFactor("activate", factor.FactorType) {
 		return "", nil
 	}
@@ -487,7 +487,7 @@ func factorChallenge(p config.Configuration, factor *factor) (string, error) {
 
 	result, err := prompt.Run()
 	if err != nil {
-		p.Logger.Debug("Prompt failed", "error", err)
+		c.Logger.Debug("Prompt failed", "error", err)
 		os.Exit(0)
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+func hasEnv() bool {
+	_, err := os.Stat("/.dockerenv")
+	return !os.IsNotExist(err)
+}
+
+func hasCGroup() bool {
+	f, _ := ioutil.ReadFile("/proc/self/cgroup")
+	return strings.Contains(string(f), "docker")
+}
+
+func InDocker() bool {
+	return hasEnv() || hasCGroup()
+}


### PR DESCRIPTION
- Eliminates the need for different `~/.okta_snowflake_login_config` variants regardless if you're running the tool in Docker
- Creates a common ODBC driver alias for Snowflake so that configs work within `unixodbc` & macOS