### PR TITLE
keyring `forget` flag, better confirm handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,8 +7,8 @@ import (
 	"syscall"
 
 	"github.com/HGInsights/gimme-snowflake-creds/internal/config"
+	okta "github.com/HGInsights/gimme-snowflake-creds/pkg/auth"
 	"github.com/HGInsights/gimme-snowflake-creds/pkg/generator"
-	"github.com/HGInsights/gimme-snowflake-creds/pkg/okta"
 	"github.com/HGInsights/gimme-snowflake-creds/pkg/utils"
 	"github.com/hashicorp/go-hclog"
 	"github.com/manifoldco/promptui"
@@ -77,6 +77,7 @@ func Execute() {
 func init() {
 	// Set flags
 	rootCmd.Flags().StringVarP(&c.ProfileName, "profile", "p", "", "profile selection")
+	rootCmd.Flags().BoolVarP(&c.Forget, "forget", "f", false, "forget saved credentials")
 	rootCmd.Flags().StringVarP(&c.Profile.Account, "account", "a", "", "Snowflake account, like: xy12345.us-east-1")
 	rootCmd.Flags().StringVarP(&c.ODBCDriverName, "driver-name", "z", "", "ODBC driver name")
 	rootCmd.Flags().StringVarP(&c.ODBCDriverPath, "driver-path", "v", "", "ODBC driver path (local)")

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
-	github.com/zalando/go-keyring v0.2.1 // indirect
+	github.com/zalando/go-keyring v0.2.1
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/ini.v1 v1.51.0

--- a/go.sum
+++ b/go.sum
@@ -212,6 +212,7 @@ github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -290,7 +291,6 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ type Configuration struct {
 	ODBCDriverPath string `mapstructure:"driver-path" validate:"required"`
 	ProfileName    string
 	Profile        Profile
+	Forget         bool
 	HomeDir        string
 	Logger         hclog.Logger
 	ColorSuccess   string


### PR DESCRIPTION
- Fixes bug where responding `N/n` to the keyring save prompt would cause the program to exit
- Adds a `--forget/-f` flag to allow the purging of saved keyring entry