### PR TITLE
Adding support for configuring dbt profiles and other hardcoded values

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,8 +84,11 @@ func init() {
 	rootCmd.Flags().StringVarP(&c.Profile.Database, "database", "d", "", "Snowflake database")
 	rootCmd.Flags().StringVarP(&c.Profile.Warehouse, "warehouse", "w", "", "Snowflake warehouse")
 	rootCmd.Flags().StringVarP(&c.Profile.Schema, "schema", "x", "PUBLIC", "Snowflake schema")
+	rootCmd.Flags().StringVar(&c.Profile.DbtProfile, "dbt-profile", "default", "What dbt profile to write to")
+	rootCmd.Flags().Uint64VarP(&c.Profile.ThreadCount, "threads", "t", 10, "The number of concurrent models dbt should build.")
 	rootCmd.Flags().BoolVarP(&c.Profile.OAuth, "oauth", "", true, "enable/disable credential retrieval")
 	rootCmd.Flags().BoolVarP(&c.Profile.Generic, "generic", "", true, "enable/disable generic credential setup")
+	rootCmd.Flags().BoolVar(&c.Profile.KeepAlive, "keep-alive", true, "the snowflake client will keep connections for longer than the default 4 hours.")
 	rootCmd.Flags().StringVarP(&c.Profile.OktaOrg, "okta-org", "o", "", "like: https://funtimes.oktapreview.com")
 	rootCmd.Flags().StringVarP(&c.Profile.ODBCPath, "odbc-path", "n", "/etc", "Path containing odbc.ini")
 	rootCmd.Flags().StringVarP(&c.Profile.ClientID, "client-id", "c", "", "OIDC Client ID of Okta application")
@@ -163,6 +166,12 @@ func initConfig(cmd *cobra.Command) error {
 	if err != nil {
 		c.Logger.Error("error", err)
 		os.Exit(0)
+	}
+
+	// Try to determine what the default
+	c.DefaultProfile = v.GetString("default")
+	if c.DefaultProfile == "" {
+		c.DefaultProfile = v.GetString("default." + c.Profile.DbtProfile)
 	}
 
 	// Load default parameters

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ var (
 )
 
 type Configuration struct {
-	DefaultProfile string `mapstructure:"default"`
+	DefaultProfile string
 	ODBCDriverName string `mapstructure:"driver-name" validate:"required"`
 	ODBCDriverPath string `mapstructure:"driver-path" validate:"required"`
 	ProfileName    string
@@ -50,6 +50,9 @@ type Profile struct {
 	Database    string `mapstructure:"database" validate:"required"`
 	Warehouse   string `mapstructure:"warehouse" validate:"required"`
 	Schema      string `mapstructure:"schema"`
+	DbtProfile  string `mapstructure:"dbt-profile"`
+	ThreadCount uint64 `mapstructure:"threads"`
+	KeepAlive   bool   `mapstructure:"client_session_keep_alive"`
 	OktaOrg     string `mapstructure:"okta-org" validate:"required,url"`
 	ODBCPath    string `mapstructure:"odbc-path" validate:"required"`
 	ClientID    string `mapstructure:"client-id" validate:"required"`


### PR DESCRIPTION
This keeps the previous configuration backwards compatible with the previous version of the configuration with some additional addons:

*  You can now configure the number of threads for dbt instead of it being hardcoded to 10 (though by default if not specificed is 10)
* You can now configure if the snowflake client connection should be kept alive longer the 4 hrs (default still false)
* You can now specify what dbt profile you would like to generate the credentials for. By default the original implementation would always have it set to the name `default` but now using `dbt-profile` you may configure a specific gimme-snowflake-creds profile to a write to a dbt profile. Note that the default output target can now be represented as either a string or a map where the string variant will just be used as a global default